### PR TITLE
Update Node.js packages to v4.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "4.4.6",
+    "node": "4.9.1",
     "npm": ">=3"
   },
   "dependencies": {


### PR DESCRIPTION
This Pull Request renovates the package group "Node.js".


-   [node](https://github.com/nodejs/node) (`engines`): from `4.4.6` to `4.9.1`