### PR TITLE
Update dependency jscs to ^3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,32 +59,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "alter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "dev": true,
-      "requires": {
-        "stable": "0.1.6"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -155,18 +129,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
-      "dev": true
-    },
-    "ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-      "dev": true
-    },
     "async": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -207,229 +169,20 @@
         }
       }
     },
-    "babel-core": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-      "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "babel-plugin-constant-folding": "1.0.1",
-        "babel-plugin-dead-code-elimination": "1.0.2",
-        "babel-plugin-eval": "1.0.1",
-        "babel-plugin-inline-environment-variables": "1.0.1",
-        "babel-plugin-jscript": "1.0.4",
-        "babel-plugin-member-expression-literals": "1.0.1",
-        "babel-plugin-property-literals": "1.0.1",
-        "babel-plugin-proto-to-assign": "1.0.4",
-        "babel-plugin-react-constant-elements": "1.0.3",
-        "babel-plugin-react-display-name": "1.0.3",
-        "babel-plugin-remove-console": "1.0.1",
-        "babel-plugin-remove-debugger": "1.0.1",
-        "babel-plugin-runtime": "1.0.7",
-        "babel-plugin-undeclared-variables-check": "1.0.2",
-        "babel-plugin-undefined-to-void": "1.1.6",
-        "babylon": "5.8.38",
-        "bluebird": "2.11.0",
-        "chalk": "1.1.3",
-        "convert-source-map": "1.5.1",
-        "core-js": "1.2.7",
-        "debug": "2.6.9",
-        "detect-indent": "3.0.1",
-        "esutils": "2.0.2",
-        "fs-readdir-recursive": "0.1.2",
-        "globals": "6.4.1",
-        "home-or-tmp": "1.0.0",
-        "is-integer": "1.0.7",
-        "js-tokens": "1.0.1",
-        "json5": "0.4.0",
-        "lodash": "3.10.1",
-        "minimatch": "2.0.10",
-        "output-file-sync": "1.1.2",
-        "path-exists": "1.0.0",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "regenerator": "0.8.40",
-        "regexpu": "1.3.0",
-        "repeating": "1.1.3",
-        "resolve": "1.6.0",
-        "shebang-regex": "1.0.0",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "source-map-support": "0.2.10",
-        "to-fast-properties": "1.0.3",
-        "trim-right": "1.0.1",
-        "try-resolve": "1.0.1"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        }
+        "core-js": "2.5.4",
+        "regenerator-runtime": "0.11.1"
       }
-    },
-    "babel-jscs": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz",
-      "integrity": "sha1-CjRwRrSBRay8pW6MjtX3NrxU+dA=",
-      "dev": true,
-      "requires": {
-        "babel-core": "5.8.38",
-        "lodash.assign": "3.2.0"
-      },
-      "dependencies": {
-        "lodash.assign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "dev": true,
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash.keys": "3.1.2"
-          }
-        }
-      }
-    },
-    "babel-plugin-constant-folding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
-      "dev": true
-    },
-    "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
-      "dev": true
-    },
-    "babel-plugin-eval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
-      "dev": true
-    },
-    "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
-      "dev": true
-    },
-    "babel-plugin-jscript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
-      "dev": true
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
-      "dev": true
-    },
-    "babel-plugin-property-literals": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
-      "dev": true
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-      "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
-      "dev": true
-    },
-    "babel-plugin-react-display-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
-      "dev": true
-    },
-    "babel-plugin-remove-console": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
-      "dev": true
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
-      "dev": true
-    },
-    "babel-plugin-runtime": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
-      "dev": true
-    },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "dev": true,
-      "requires": {
-        "leven": "1.0.2"
-      }
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
-      "dev": true
     },
     "babylon": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-      "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -454,12 +207,6 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
-    },
-    "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-      "dev": true
     },
     "body-parser": {
       "version": "1.18.2",
@@ -538,12 +285,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "breakable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
@@ -584,16 +325,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -739,56 +470,6 @@
         "readable-stream": "2.3.5"
       }
     },
-    "commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "dev": true,
-      "requires": {
-        "commander": "2.9.0",
-        "detective": "4.7.1",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.19",
-        "mkdirp": "0.5.1",
-        "private": "0.1.8",
-        "q": "1.5.1",
-        "recast": "0.11.23"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "recast": {
-          "version": "0.11.23",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          }
-        }
-      }
-    },
     "compressible": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
@@ -857,12 +538,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
-    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -874,9 +549,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
       "dev": true
     },
     "core-util-is": {
@@ -934,20 +609,22 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
+    "cst": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/cst/-/cst-0.4.10.tgz",
+      "integrity": "sha512-U5ETe1IOjq2h56ZcBE3oe9rT7XryCH6IKgPMv0L7sSk6w29yR3p5egCK0T3BDNHHV95OoUBgXsqiVG+3a900Ag==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babylon": "6.18.0",
+        "source-map-support": "0.4.18"
+      }
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.42"
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -987,81 +664,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
-    "defs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
-      "dev": true,
-      "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
-        }
-      }
-    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -1099,44 +701,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-indent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        }
-      }
-    },
-    "detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.5.3",
-        "defined": "1.0.0"
-      }
     },
     "doctrine": {
       "version": "2.1.0",
@@ -1243,77 +807,6 @@
         "escape-html": "1.0.3"
       }
     },
-    "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1323,18 +816,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
-      }
     },
     "eslint": {
       "version": "4.19.1",
@@ -1509,16 +990,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
-      }
     },
     "execa": {
       "version": "0.7.0",
@@ -1741,12 +1212,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-readdir-recursive": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1763,12 +1228,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -1911,24 +1370,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-    },
-    "home-or-tmp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "user-home": "1.1.1"
-      },
-      "dependencies": {
-        "user-home": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-          "dev": true
-        }
-      }
     },
     "htmlparser2": {
       "version": "3.8.3",
@@ -2127,27 +1568,12 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
         "ci-info": "1.1.3"
-      }
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -2162,15 +1588,6 @@
       "requires": {
         "global-dirs": "0.1.1",
         "is-path-inside": "1.0.1"
-      }
-    },
-    "is-integer": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
       }
     },
     "is-npm": {
@@ -2264,12 +1681,6 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
       "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
     },
-    "js-tokens": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-      "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -2287,23 +1698,21 @@
       "optional": true
     },
     "jscs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
-      "integrity": "sha1-bhHvDKqgdzH53MKysn2OzuHdvLY=",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/jscs/-/jscs-3.0.7.tgz",
+      "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
       "dev": true,
       "requires": {
-        "babel-jscs": "2.0.5",
         "chalk": "1.1.3",
         "cli-table": "0.3.1",
         "commander": "2.9.0",
-        "escope": "3.6.0",
-        "esprima": "2.7.3",
+        "cst": "0.4.10",
         "estraverse": "4.2.0",
         "exit": "0.1.2",
         "glob": "5.0.15",
         "htmlparser2": "3.8.3",
         "js-yaml": "3.4.6",
-        "jscs-jsdoc": "1.3.2",
+        "jscs-jsdoc": "2.0.0",
         "jscs-preset-wikimedia": "1.0.1",
         "jsonlint": "1.6.3",
         "lodash": "3.10.1",
@@ -2367,9 +1776,9 @@
       }
     },
     "jscs-jsdoc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz",
-      "integrity": "sha1-HyyCtqtLl1JNqVj0a05WLgMF+ac=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-2.0.0.tgz",
+      "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
       "dev": true,
       "requires": {
         "comment-parser": "0.3.2",
@@ -2398,12 +1807,6 @@
           "dev": true
         }
       }
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
     },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
@@ -2491,12 +1894,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-      "dev": true
-    },
     "jsonlint": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
@@ -2518,15 +1915,6 @@
         "verror": "1.10.0"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -2535,12 +1923,6 @@
         "package-json": "4.0.1"
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -2548,12 +1930,6 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
-    },
-    "leven": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
-      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -2583,86 +1959,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/lodash-id/-/lodash-id-0.14.0.tgz",
       "integrity": "sha1-uvSJNOVDobXWNG+MhGmLGoyAOJY="
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
     },
     "lowdb": {
       "version": "0.15.5",
@@ -2797,9 +2093,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nanoid": {
@@ -2823,12 +2119,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
     },
     "nomnom": {
       "version": "1.8.1",
@@ -2933,15 +2223,6 @@
         "wordwrap": "1.0.0"
       }
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
-    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -2953,17 +2234,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -3108,12 +2378,6 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -3157,12 +2421,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
     },
     "qs": {
       "version": "6.5.1",
@@ -3232,7 +2490,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "0.0.5"
+        "mute-stream": "0.0.7"
       }
     },
     "readable-stream": {
@@ -3250,86 +2508,17 @@
         "util-deprecate": "1.0.2"
       }
     },
-    "recast": {
-      "version": "0.10.33",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.8.12",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.12",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
-          "dev": true
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
-      }
-    },
-    "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
-    },
-    "regenerator": {
-      "version": "0.8.40",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-      "dev": true,
-      "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
-        "recast": "0.10.33",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
-      }
     },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
-    },
-    "regexpu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-      "dev": true,
-      "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.33",
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        }
-      }
     },
     "registry-auth-token": {
       "version": "3.3.2",
@@ -3347,27 +2536,6 @@
       "requires": {
         "rc": "1.2.6"
       }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      }
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
     },
     "request": {
       "version": "2.85.0",
@@ -3461,15 +2629,6 @@
       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
     },
     "rimraf": {
       "version": "2.6.2",
@@ -3593,24 +2752,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
-      "dev": true
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
-      "dev": true
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -3635,23 +2776,12 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-      "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.1.32"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
+        "source-map": "0.5.7"
       }
     },
     "spawn-sync": {
@@ -3684,12 +2814,6 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
-    },
-    "stable": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
-      "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -3742,18 +2866,6 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
-    },
-    "stringmap": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
-      "dev": true
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3878,12 +2990,6 @@
       "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
     "to-single-quotes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
@@ -3897,24 +3003,6 @@
       "requires": {
         "punycode": "1.4.1"
       }
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "try-resolve": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
-      "dev": true
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "eslint": "^4.0.0",
-    "jscs": "^2.7.0",
+    "jscs": "^3.0.0",
     "pre-commit": "^1.1.2"
   },
   "pre-commit": [


### PR DESCRIPTION
This Pull Request updates dependency [jscs](https://github.com/jscs-dev/node-jscs) from `^2.7.0` to `^3.0.0`



<details>
<summary>Release Notes</summary>

### [`v3.0.0`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-301httpsgithubcomjscs-devnode-jscscomparev300v301-2016-02-14)

##### Bug fixes
- disallowUnusedVariables: was including function expressions

---

### [`v3.0.1`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-302httpsgithubcomjscs-devnode-jscscomparev301v302-2016-02-15)

##### Bug fixes
- Revert all rule deprecations

---

### [`v3.0.2`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-303httpsgithubcomjscs-devnode-jscscomparev302v303-2016-02-16)

##### Bug fixes
- Misc: Make an exception for esnext/verbose since they are removed 
- Revert "Configuration: exclude nested node_modules by default

---

### [`v3.0.3`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-304httpsgithubcomjscs-devnode-jscscomparev303v304-2016-06-04)

Fixed some bugs, correctly output CST errors plus improve speed and memory consumption
##### Bug fixes
* requireObjectKeysOnNewLine: do not break on object methods (Oleg Gaidarenko)
* Fix: Last method throw in requireObjectKeysOnNewLine (Alexey Yaroshevich)
* disallowQuotedKeysInObjects: ignore spread properties (Oleg Gaidarenko)
* maximumLineLength: correctly position error for comment nodes (Oleg Gaidarenko)
* disallowUnusedParams: notice AssignmentPattern nodes (Oleg Gaidarenko)
* disallowPaddingNewlinesBeforeKeywords: should not ignore comments (Oleg Gaidarenko)
* disallowObjectKeysOnNewLine: correct error message (Oleg Gaidarenko)
##### Misc
* Misc: make linters happy (Oleg Gaidarenko)
* Misc: add node 6 to travis (Oleg Gaidarenko)
* Misc: do not modify CST in check mode (#&#8203;2252) (Oleg Gaidarenko)
* Misc: remove rules "grouping" (Oleg Gaidarenko)
* Misc: bump cst version (Oleg Gaidarenko)
* Tests: remove mocha `.only` call (Oleg Gaidarenko)
* Misc: parallelizing build on travis (Alexey Yaroshevich)
* Misc: Set higher timeout for config generator tests (Alexey Yaroshevich)
* Build: update cst to 0.3.0 (Henry Zhu)
* Errors: add ugly exception for `validateQuoteMarks` of position calc (Oleg Gaidarenko)
* Errors: always add to `line` and `column` properties (Oleg Gaidarenko)
##### Docs
* Docs: Fix small typo in require-early-return (#&#8203;2259) (Sander Boom)
* add jscs+eslint info (#&#8203;2230) (Henry Zhu)
* Docs: simplify readme a bit more (Oleg Gaidarenko)
* Docs: deprecation clean-up (Oleg Gaidarenko)
* requireCurlyBraces: small docs corrections (Oleg Gaidarenko)

---

### [`v3.0.4`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-305httpsgithubcomjscs-devnode-jscscomparev304v305-2016-06-21)

Small fixes for ES6/7 related to [CST](https://github.com/cst/cst) which consisted of updating this package since those fixes were made in there. 

And also there is one fix related to `fileExtension` option
##### Bug fixes
* Configuration: Do not set default options if preset is set (Oleg Gaidarenko)
* Misc: bump CST version to 0.4.0 (Oleg Gaidarenko)
* Docs: remove yandex preset from overview (Oleg Gaidarenko)
* Docs: add intro delimiter to readme (Oleg Gaidarenko)
* Misc: use correct headers in changelog (Oleg Gaidarenko)
* Misc: correct changelog auto-replace result (Oleg Gaidarenko)
* Misc: correct changelog jscs version (Oleg Gaidarenko)
* Misc: changelog should be consistent (Oleg Gaidarenko)

---

### [`v3.0.5`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-306httpsgithubcomjscs-devnode-jscscomparev305v306-2016-07-01)

##### Bug fixes

* requireDollarBeforejQueryAssignment: do not blow up on reset parameter (Oleg Gaidarenko)
##### Misc
* Misc: explicitly use latest CST version (Oleg Gaidarenko)
* Misc: fix typo in the changelog (Oleg Gaidarenko)
* Misc: bump CST version to 0.4.2 (Oleg Gaidarenko)

---

### [`v3.0.6`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-307httpsgithubcomjscs-devnode-jscscomparev306v307-2016-07-14)

* validateParameterSeparator: notice class methods (Oleg Gaidarenko)

---

### [`v3.0.7`](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#Version-307httpsgithubcomjscs-devnode-jscscomparev306v307-2016-07-14)

* validateParameterSeparator: notice class methods (Oleg Gaidarenko)

---

</details>


<details>
<summary>Commits</summary>

#### v3.0.0
-   [`83a1647`](https://github.com/jscs-dev/node-jscs/commit/83a16478acbed90ad5b4129897b7b54f491f2037) requireCapitalizedComments: do not use `getLoc` method
-   [`b4bf41a`](https://github.com/jscs-dev/node-jscs/commit/b4bf41a13576e91cf634345e38b0375b265a6579) [Performance] Fix spaces between assert
-   [`479d071`](https://github.com/jscs-dev/node-jscs/commit/479d071439ab82a8f37b05019a3872e27e9ff8db) [Perf] Remove another getRange()
-   [`56a84ba`](https://github.com/jscs-dev/node-jscs/commit/56a84ba61ec1dfe774a1304bef6db3f4a853ea5b) disallowSpacesInConditionalExpression: do not use `getLoc` method
-   [`ff293c9`](https://github.com/jscs-dev/node-jscs/commit/ff293c95da39c301a8ac1d56c2da5d074b821293) [Perf] Remove getRange() from rules
-   [`ebeca63`](https://github.com/jscs-dev/node-jscs/commit/ebeca634d2e6b0bab2d42a476cb1d980df0a71f7) validateAlignedFunctionParameters: use file#isOnTheSameLine if possible
-   [`c2f6112`](https://github.com/jscs-dev/node-jscs/commit/c2f6112d9698ce86f6d135a0ded5008e4855d3c4) [Perf] Remove getRange() from token categorizer
-   [`c2c4d5d`](https://github.com/jscs-dev/node-jscs/commit/c2c4d5d5078fc35becf6120fb3b8425fe7cf6578) [Perf] Remove getNodeByRange
-   [`0e9f4fa`](https://github.com/jscs-dev/node-jscs/commit/0e9f4fa2c547b2a252a5ad0634ce7183704d7daf) [Perf] Remove getLoc from linesBetween() method
-   [`d480c30`](https://github.com/jscs-dev/node-jscs/commit/d480c3006c8079e685dd8e5c2d574c8a12749549) [Fix] Remove unused tokenBefore / noTokenBefore
-   [`7363537`](https://github.com/jscs-dev/node-jscs/commit/7363537a9e2b656d475ab46c99b7fc2aa6064fa9) [Perf] Remove getLoc() in TokenAssert.indentation and requireAlignedMultilineParams
-   [`b49097c`](https://github.com/jscs-dev/node-jscs/commit/b49097cd164f369396b471f048c25499a97cfbab) [Perf] Remove JsFile.getFirstTokenOnLine
-   [`f3e70db`](https://github.com/jscs-dev/node-jscs/commit/f3e70db8bfe7cee9fe2814a15ca9b1c876787d94) fix cst url
-   [`85b2f28`](https://github.com/jscs-dev/node-jscs/commit/85b2f286d01e60f1f00610b98d7bfaacfb830a82) fixup linting issues
-   [`7a8052a`](https://github.com/jscs-dev/node-jscs/commit/7a8052a392bfbee22b990871a5d28ffadbcf173f) es5
-   [`c5f4aa2`](https://github.com/jscs-dev/node-jscs/commit/c5f4aa2450ddcdc6f0ea680da174fa4720219f6b) Misc: bump cst version
-   [`df355fa`](https://github.com/jscs-dev/node-jscs/commit/df355fa47569de6c4149aa114dbf7f78b4e34703) New rule: disallowUnusedVariables
-   [`16d861e`](https://github.com/jscs-dev/node-jscs/commit/16d861ed5aee769ba4ad0ea27946c8de51766aab) Misc: divide lint commands
-   [`cca477e`](https://github.com/jscs-dev/node-jscs/commit/cca477eb88c152294aa9650ce3e73c02bb502bc6) disallowUnusedVariables: adapt to cst 0.1.3
-   [`ea7f31e`](https://github.com/jscs-dev/node-jscs/commit/ea7f31ee75ea2a049388a386e9b23fda208f6093) Misc: Bump cst version and re-enable integration tests
-   [`affa854`](https://github.com/jscs-dev/node-jscs/commit/affa854db11c807d4d24712c17796a6d27f55b4c) Preset: allow URLs inside comments for airbnb
-   [`db5b76c`](https://github.com/jscs-dev/node-jscs/commit/db5b76c73edd278b72ba55ec03aee93fc065ff39) [Fix] Error fixes
-   [`9ce5130`](https://github.com/jscs-dev/node-jscs/commit/9ce513030112cbf536331ad5f5e5d987a6389012) [Fix] JsDoc plugin dep
-   [`b09ef84`](https://github.com/jscs-dev/node-jscs/commit/b09ef84d950fe0e5639e23a89f3ca4a14ec50ba4) [Fix] Remaining style issues
-   [`c82294f`](https://github.com/jscs-dev/node-jscs/commit/c82294fec740686356d079ca93fec446867665f5) [Fix] Unskip generator tests
-   [`4517263`](https://github.com/jscs-dev/node-jscs/commit/451726384b8cdc4373a2480b690005a81e24224e) [Fix] Keywords in identifiers
-   [`5b6f8de`](https://github.com/jscs-dev/node-jscs/commit/5b6f8decfc4adcc93796efc51343fa81f6bc322b) [Fix] Parsing errors
-   [`4bd3800`](https://github.com/jscs-dev/node-jscs/commit/4bd3800d554d4175390e3d5be24ea0a2d93dc041) [Fix] Parsing errors
-   [`90fae1a`](https://github.com/jscs-dev/node-jscs/commit/90fae1aeddf6d05288264e079d1db5a89c107fd4) [Perf] Reduce location computations
-   [`291bb41`](https://github.com/jscs-dev/node-jscs/commit/291bb4143d427eb488a75c6533f04a2937957d18) Docs: remove leftover of yandex preset
-   [`86be5b5`](https://github.com/jscs-dev/node-jscs/commit/86be5b5ec6f7e52f36b9e159a55d71e4b87d3edc) Tests: skip the generator tests
-   [`a855828`](https://github.com/jscs-dev/node-jscs/commit/a8558280c8819148c0a987e099e8c3e1e7798998) Tests: remove unstable generator test and re-enable it
-   [`e005fd3`](https://github.com/jscs-dev/node-jscs/commit/e005fd3ff40f012b1c0fb47c0ba5c26e6f9f6591) Misc: make linters happy
-   [`7cfe388`](https://github.com/jscs-dev/node-jscs/commit/7cfe38893beb8cfe4ae07904d311296068887e25) Tests: one last improvement to generator tests
-   [`743dd8c`](https://github.com/jscs-dev/node-jscs/commit/743dd8cae16911725071daf91543212eaf312a5b) Misc: add 3.0.0 changelog
-   [`c3a5e8a`](https://github.com/jscs-dev/node-jscs/commit/c3a5e8a751d567c987c8b2466dbfef3197079846) 3.0.0
#### v3.0.1
-   [`6c6cda4`](https://github.com/jscs-dev/node-jscs/commit/6c6cda482e792babe5978a05b39b1d640c0da6b5) Misc: remove leftover from the browser version
-   [`096b6bf`](https://github.com/jscs-dev/node-jscs/commit/096b6bf0bebc34e8a028a722d584a70af1168c2a) Docs: use &quot;http&quot; protocol in changelog
#### v3.0.2
-   [`35992b1`](https://github.com/jscs-dev/node-jscs/commit/35992b15ade32c640b3dcf40f5bbc135b76f2c4b) [Fix] disallowUnusedVariables included function expressions
-   [`d83cee0`](https://github.com/jscs-dev/node-jscs/commit/d83cee0a92703b8549de4077de427cfbc49ffc87) 3.0.1
-   [`ca68499`](https://github.com/jscs-dev/node-jscs/commit/ca68499d56a632a9331a2d50444362ffa54f0ec9) Docs: fix changelog [ci skip]
-   [`b05dd8a`](https://github.com/jscs-dev/node-jscs/commit/b05dd8ab1526a65503c870cb85bda7a508032514) Docs: Update changelog [ci skip]
-   [`baede85`](https://github.com/jscs-dev/node-jscs/commit/baede85f7f09de98dae22bf1b7b8b8e25fa3c0b2) Fix: Revert rule value deprecations (#&#8203;2217)
-   [`2ec1378`](https://github.com/jscs-dev/node-jscs/commit/2ec1378d63263357c86f7e32d54fba5c7ff731b8) Docs: add 3.0.1 and 3.0.2 changelog
-   [`9ce1c9b`](https://github.com/jscs-dev/node-jscs/commit/9ce1c9bd58d9a860b4d49ea8bba7b794ba7a75ab) 3.0.2
#### v3.0.3
-   [`4a935aa`](https://github.com/jscs-dev/node-jscs/commit/4a935aa0bd8ad45595bcf0c57adfa232c6c0de07) Revert &quot;Configuration: exclude nested node_modules by default&quot; (#&#8203;2222)
-   [`244de06`](https://github.com/jscs-dev/node-jscs/commit/244de0627e8bdb8d645a415c1bdd7d3a7a7d8e34) Misc: Make an exception for esnext/verbose since they are removed (#&#8203;2208)
-   [`1b5f065`](https://github.com/jscs-dev/node-jscs/commit/1b5f06555ec0e616c32649ac9bd52017d01b4d60) Docs: 3.0.3 changelog [ci skip]
-   [`3c3c33f`](https://github.com/jscs-dev/node-jscs/commit/3c3c33f91607066ceeec7192454cbc09fc10a672) 3.0.3
#### v3.0.4
-   [`f611d0c`](https://github.com/jscs-dev/node-jscs/commit/f611d0cf8da7965d400ab2f9c4ff489d0c0f0598) add jscs+eslint info (#&#8203;2230)
-   [`e878832`](https://github.com/jscs-dev/node-jscs/commit/e878832201d4d1c92655b50429691230a0618248) Misc: Set higher timeout for config generator tests
-   [`be0734f`](https://github.com/jscs-dev/node-jscs/commit/be0734f765409ef0063d8dedfbaad44e6e6292fc) Misc: parallelizing build on travis
-   [`80203a1`](https://github.com/jscs-dev/node-jscs/commit/80203a100a9049c0ad12d8670d80bb7ead17aa24) Fix: Last method throw in requireObjectKeysOnNewLine
-   [`bba8c15`](https://github.com/jscs-dev/node-jscs/commit/bba8c1587fd0f83838d3acae6b6c77c9b0adb12e) Docs: deprecation clean-up
-   [`2cdb26d`](https://github.com/jscs-dev/node-jscs/commit/2cdb26d172fc8e19779dffcbab88ca8ab8f06fb9) Docs: simplify readme a bit more
-   [`bbb03b5`](https://github.com/jscs-dev/node-jscs/commit/bbb03b51f3177fe6aa1d7b98d9c6d8d0f334e278) requireObjectKeysOnNewLine: do not break on object methods
-   [`729db94`](https://github.com/jscs-dev/node-jscs/commit/729db94f86902496f3962a4a97bdd91a75ab5514) Errors: always add to `line` and `column` properties
-   [`819e75c`](https://github.com/jscs-dev/node-jscs/commit/819e75ca67b42c920eb7d7b3af74c6f8b6be3952) disallowObjectKeysOnNewLine: correct error message
-   [`8441d6f`](https://github.com/jscs-dev/node-jscs/commit/8441d6fc0d44481891712ab447887e59f4a85d44) Errors: add ugly exception for `validateQuoteMarks` of position calc
-   [`2390485`](https://github.com/jscs-dev/node-jscs/commit/2390485853aa4604970fc4aca8b802f71487a9d5) disallowQuotedKeysInObjects: ignore spread properties
-   [`9eaa1f7`](https://github.com/jscs-dev/node-jscs/commit/9eaa1f7c619a356b4d887c60760d2eb36543a59f) Tests: remove mocha `.only` call
-   [`fa4ee36`](https://github.com/jscs-dev/node-jscs/commit/fa4ee367c2ad9a0912f4cd3e5f0fa27dffb92535) Misc: bump cst version
-   [`9ea70d2`](https://github.com/jscs-dev/node-jscs/commit/9ea70d25bcc87181bd770c67c77f7979a1af5785) Misc: remove rules &quot;grouping&quot;
-   [`724b2df`](https://github.com/jscs-dev/node-jscs/commit/724b2df8e2fa1db75ff0fc61dab86ca7efc67a47) Misc: do not modify CST in check mode (#&#8203;2252)
-   [`3b2f6de`](https://github.com/jscs-dev/node-jscs/commit/3b2f6de48b8c9896c9b385f767947f5637a711ab) Misc: add node 6 to travis
-   [`7b8d6b0`](https://github.com/jscs-dev/node-jscs/commit/7b8d6b0e842555cd2ac642405ce465d60ac2a216) Misc: make linters happy
-   [`29d1b00`](https://github.com/jscs-dev/node-jscs/commit/29d1b00717e1238e9400ce41af9368ef2136845e) requireCurlyBraces: small docs corrections
-   [`f3be3d6`](https://github.com/jscs-dev/node-jscs/commit/f3be3d6640ddfb6ae915c0ee1746585b86d29f5f) disallowPaddingNewlinesBeforeKeywords: should not ignore comments
-   [`a215e67`](https://github.com/jscs-dev/node-jscs/commit/a215e672ad76270881bfc7252a954762119c48a3) Build: update cst to 0.3.0
-   [`e948d70`](https://github.com/jscs-dev/node-jscs/commit/e948d7074abe250f0508ae0c77851dce06a0baac) Docs: Fix small typo in require-early-return (#&#8203;2259)
-   [`ea1ebb9`](https://github.com/jscs-dev/node-jscs/commit/ea1ebb9fef2a5531e712b223231a39d19005abd3) disallowUnusedParams: notice AssignmentPattern nodes
-   [`56ca72b`](https://github.com/jscs-dev/node-jscs/commit/56ca72b77d56b53c2595c0f030cd1465dbd09595) maximumLineLength: correctly position error for comment nodes
-   [`584c556`](https://github.com/jscs-dev/node-jscs/commit/584c556840dc2a3d67622d4195e4cc65a2ff76ae) Tests: do not run integration tests
-   [`3c64a00`](https://github.com/jscs-dev/node-jscs/commit/3c64a0035766300baab306188dc3a0dea8e17f4b) Misc: add 3.0.4 changelog
-   [`f867612`](https://github.com/jscs-dev/node-jscs/commit/f867612b50bc68e4274c2f055812e8acad86b5ea) 3.0.4
#### v3.0.5
-   [`8132a87`](https://github.com/jscs-dev/node-jscs/commit/8132a87aea3c9731dc8aaa093b31c8929a747d95) Misc: changelog should be consistent
-   [`747d058`](https://github.com/jscs-dev/node-jscs/commit/747d05834b6593312b84ac7f4d7f67342959cefb) Misc: correct changelog jscs version
-   [`508982c`](https://github.com/jscs-dev/node-jscs/commit/508982cf732d40f3b4ab2073ba4798f644c7cadc) Misc: correct changelog auto-replace result
-   [`c4474c1`](https://github.com/jscs-dev/node-jscs/commit/c4474c1bd5cb383a697574d6cceb90da7d350ee2) Misc: use correct headers in changelog
-   [`dbff270`](https://github.com/jscs-dev/node-jscs/commit/dbff270b3062c9fca39925712f6e5bf8bc97b05a) Docs: add intro delimiter to readme
-   [`ae3666a`](https://github.com/jscs-dev/node-jscs/commit/ae3666a8b24848a3e20cbe0bd8e6bff633b67190) Docs: remove yandex preset from overview
-   [`5885239`](https://github.com/jscs-dev/node-jscs/commit/5885239955167317593c0896420651c46114b135) Misc: bump CST version to 0.4.0
-   [`0d027a7`](https://github.com/jscs-dev/node-jscs/commit/0d027a7b4a95c7c349f57ffd37f10e497d66a5d4) Configuration: Do not set default options if preset is set
-   [`ea2c3f7`](https://github.com/jscs-dev/node-jscs/commit/ea2c3f7020cc200cd93db409b1f01975b6cba7b4) Configuration: move hasCorrectExtension to more appropriate place
-   [`a5e5bde`](https://github.com/jscs-dev/node-jscs/commit/a5e5bde7fccf78388cb40093d3b953113b36cadb) Misc: add 3.0.5 changelog
-   [`67f3cd9`](https://github.com/jscs-dev/node-jscs/commit/67f3cd90f667370b5278d885e306cf118487b7f8) 3.0.5
#### v3.0.6
-   [`71dd3dd`](https://github.com/jscs-dev/node-jscs/commit/71dd3dd3cd5a55558dee97a385c57251cb6eddd9) Misc: bump CST version to 0.4.2
-   [`f3cdfac`](https://github.com/jscs-dev/node-jscs/commit/f3cdfac6a49815f18e1fdad5550b095600a578e8) Misc: fix typo in the changelog
-   [`b419c66`](https://github.com/jscs-dev/node-jscs/commit/b419c66b593474b906e29cfd3ac44ad938391fec) Misc: explicitly use latest CST version
-   [`6ae32ac`](https://github.com/jscs-dev/node-jscs/commit/6ae32aca929afe1344866aaa052820e306065df3) requireDollarBeforejQueryAssignment: do not blow up on reset parameter
-   [`a14b499`](https://github.com/jscs-dev/node-jscs/commit/a14b49912c80ba77a4b6b4e891a5d7ccf197a6ad) Misc: add 3.0.6 changelog
-   [`92fa964`](https://github.com/jscs-dev/node-jscs/commit/92fa9645f504f4c273dbce701a29df34f5b4fb57) 3.0.6
#### v3.0.7
-   [`47d19e1`](https://github.com/jscs-dev/node-jscs/commit/47d19e1a0dc7f35ec0b8c50af4e35eaf1291b9cb) validateParameterSeparator: notice class methods
-   [`bc0c425`](https://github.com/jscs-dev/node-jscs/commit/bc0c425e4e4d7dfdb3c20de4f667e08f616fa809) Misc: add changelog for 3.0.7
-   [`e177990`](https://github.com/jscs-dev/node-jscs/commit/e177990d913aafd3e96870a9202194cbbda05167) 3.0.7

</details>